### PR TITLE
ODSP-284: Removed link prefix for Vocabulary URI

### DIFF
--- a/tsv_files/variableInformation.tsv
+++ b/tsv_files/variableInformation.tsv
@@ -15,7 +15,7 @@
 	odisseiConceptVariableWaardestelselnaam	Value system name	Value system name indicated by CBS.		textbox	17	- <b>#NAME:</b> #VALUE <br>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableId	ID	Id to uniquely identify the variable.		textbox	4	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableLabel	Label	Short description of the variable.		textbox	2	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
-	odisseiVariableVocabularyURI	Vocabulary URI	Vocabulary URI for the variable.	https://	url	19	- <b>#NAME:</b> <a href='https://skosmos.odissei.nl/cbs/nl/page/?clang=nl&uri=#VALUE' target='_blank'>#VALUE</a> <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
+	odisseiVariableVocabularyURI	Vocabulary URI	Vocabulary URI for the variable.	https://	url	19	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableDefinition	Definition	Extra information related to the definition of the variable.		textbox	3	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableProcessingInstruction	Processing Instruction	Information about how the variable was processed.		textbox	6	- <b>#NAME:</b> #VALUE <br>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableDataType	Data Type	Data type of the variable.		textbox	5	- <b>#NAME:</b> #VALUE <br>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	

--- a/tsv_files/variableInformation.tsv
+++ b/tsv_files/variableInformation.tsv
@@ -15,7 +15,7 @@
 	odisseiConceptVariableWaardestelselnaam	Value system name	Value system name indicated by CBS.		textbox	17	- <b>#NAME:</b> #VALUE <br>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableId	ID	Id to uniquely identify the variable.		textbox	4	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableLabel	Label	Short description of the variable.		textbox	2	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
-	odisseiVariableVocabularyURI	Vocabulary URI	Vocabulary URI for the variable.	https://	url	19	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
+	odisseiVariableVocabularyURI	Vocabulary URI	Vocabulary URI for the variable.	https://	url	19	- <b>#NAME:</b> <a href='#VALUE' target='_blank'>#VALUE</a> <br>	TRUE	FALSE	FALSE	TRUE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableDefinition	Definition	Extra information related to the definition of the variable.		textbox	3	- <b>#NAME:</b> #VALUE <br>	TRUE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableProcessingInstruction	Processing Instruction	Information about how the variable was processed.		textbox	6	- <b>#NAME:</b> #VALUE <br>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	
 	odisseiVariableDataType	Data Type	Data type of the variable.		textbox	5	- <b>#NAME:</b> #VALUE <br>	FALSE	FALSE	FALSE	FALSE	FALSE	FALSE	odisseiVariable	variableInformation	


### PR DESCRIPTION
See Jira Issue : https://drivenbydata.atlassian.net/browse/ODSP-284

For testing this, the tsv file must be copied to the server and the 'curl' command must be run there. 
This is also done in the scripts provided by the `odissei-data/odissei-dataverse-stack` Github project.

### Testing:

When I have that adapted tsv file in `~/git/Custom-Metadata-Blocks/tsv_files/variableInformation.tsv`. 
In my `odissei-dataverse-stack` git project dir and copy it to the container: 

```
docker cp ~/git/Custom-Metadata-Blocks/tsv_files/variableInformation.tsv dev_dataverse:/opt/payara/
```

Then upload it into Dataverse:
```
docker exec dev_dataverse curl http://localhost:8080/api/admin/datasetfield/load -H "Content-type: text/tab-separated-values" -X POST --upload-file variableInformation.tsv
```

